### PR TITLE
Allowing for other S3 providers

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -19,7 +19,7 @@ Upload = module.exports = (awsBucketName, opts) ->
   @versions = opts?.versions or []
 
   @awsBucketPath = opts?.awsBucketPath or ''
-  @awsBucketUrl = "https://s3-#{opts?.awsBucketRegion or 'us-east-1'}.amazonaws.com/#{awsBucketName}/"
+  @awsBucketUrl = "https://#{awsServersUrl}/#{awsBucketName}/"
   @awsBucketAcl = opts?.awsBucketAcl or 'privat'
 
   @resizeQuality = opts?.resizeQuality or 70


### PR DESCRIPTION
Change awsBucket to accept a awsServersUrl to allow for other S3 compatible providers to be used instead of hard coding to amazon. 

I'm not a coffescript developer so i'm not certain if this is the correct approach, but you get the general idea