### PR TITLE
Add support for custom random path function

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ var Upload = require('s3-uploader');
     * **number** `awsImageExpires` - add `Expires` header to image version
     * **number** `awsImageCacheControl` - add `Cache-Control` header to image version
 
+  * **function** `randomPath` - custom random path function
+
 #### AWS note
 > The `aws` object is passed directly to `aws-sdk`. You can add any of [these
 > options](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#constructor_details)

--- a/package.json
+++ b/package.json
@@ -40,9 +40,11 @@
   "devDependencies": {
     "coffee-script": "~1",
     "coffeelint": "~1",
-    "mocha": "~2"
+    "mocha": "~2",
+    "uuid": "^2"
   },
   "dependencies": {
+    "@starefossen/rand-path": "^1.0.1",
     "async": "~1.4",
     "aws-sdk": "~2.1",
     "im-resize": "~2.3",

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -41,23 +41,11 @@ Upload = module.exports = (bucketName, @opts = {}) ->
   else if not @opts.url
     @opts.url ?= "https://s3-#{@opts.aws.region}.amazonaws.com/#{bucketName}/"
 
+  @._getRandomPath = @opts.randomPath or require('@starefossen/rand-path')
+
   @s3 = new S3 @opts.aws
 
   @
-
-##
-# Generate a random path on the form /xx/yy/zz
-##
-Upload.prototype._getRandomPath = ->
-  input = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
-  res = []
-
-  for i in [1..3]
-    x = input[Math.floor((Math.random() * input.length))]
-    y = input[Math.floor((Math.random() * input.length))]
-    res.push x + y
-
-  return res.join '/'
 
 ##
 # Generate a random avaiable path on the S3 bucket

--- a/test/suite.coffee
+++ b/test/suite.coffee
@@ -123,7 +123,14 @@ describe 'Upload', ->
   describe '#_getRandomPath()', ->
     it 'returns a new random path', ->
       path = upload._getRandomPath()
-      assert(/^[A-Za-z0-9]{2}\/[A-Za-z0-9]{2}\/[A-Za-z0-9]{2}$/.test(path))
+      assert(/^\w{2}(\/\w{2}){2}$/.test(path))
+
+    it 'returns custom random path', ->
+      upload = new Upload process.env.AWS_BUCKET_NAME,
+        randomPath: require('uuid').v1
+
+      path = upload._getRandomPath()
+      assert(/^\w+(-\w+){4}$/.test(path))
 
   describe '#_getDestPath()', ->
     beforeEach ->


### PR DESCRIPTION
This PR implements support for #20 Custom random path generator function.

**Usage:**

```js
var upload = new Upload(process.env.AWS_BUCKET_NAME, {
  randomPath: require('uuid').v1
});
```