### PR TITLE
Fix typo in default acl param

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -16,7 +16,7 @@ Upload = module.exports = (bucketName, @opts = {}) ->
 
   @opts.aws                     ?= {}
   #@opts.aws.accessKeyId
-  @opts.aws.acl                 ?= 'privat'
+  @opts.aws.acl                 ?= 'private'
   @opts.aws.httpOptions         ?= {}
   @opts.aws.httpOptions.timeout ?= 10000
   @opts.aws.maxRetries          ?= 3

--- a/test/suite.coffee
+++ b/test/suite.coffee
@@ -74,7 +74,7 @@ describe 'Upload', ->
       assert upload.s3 instanceof require('aws-sdk').S3
       assert.deepEqual upload.opts,
         aws:
-          acl: 'privat'
+          acl: 'private'
           httpOptions: timeout: 10000
           maxRetries: 3
           params: Bucket: 'myBucket'


### PR DESCRIPTION
Hello.

Pretty annoying typo. If you use default settings to upload image, aws will return an error saying:
````javascript
{
  Code: 'InvalidArgument',
  Message: '',
  ArgumentName: 'x-amz-acl',
  ArgumentValue: 'privat',
  RequestId: '*****',
  HostId: '****' 
}
````
And just to be 100% sure, here http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPUT.html#rest-object-put-access-permissions `privat` is not listed as valid value for `x-amz-acl`:
```
Valid Values: private | public-read | public-read-write | ....
```

Hope this helps ;)