### PR TITLE
Add support for AWS S3 cache control headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,13 @@ var Upload = require('s3-uploader');
     * **string** `background` - set background for transparent images (**example:** `red`)
     * **boolean** `flatten` - flatten backgrund for transparent images
     * **string** `awsImageAcl` - access control for AWS S3 upload (**example:** `private`)
+    * **number** `awsImageExpires` - add `Expires` header to image version
+    * **number** `awsImageCacheControl` - add `Cache-Control` header to image version
 
   * **object** `original`
     * **string** `awsImageAcl` - access control for AWS S3 upload (**example:** `private`)
+    * **number** `awsImageExpires` - add `Expires` header to image version
+    * **number** `awsImageCacheControl` - add `Cache-Control` header to image version
 
 #### AWS note
 > The `aws` object is passed directly to `aws-sdk`. You can add any of [these


### PR DESCRIPTION
Add support for `Expires` and `Caceh-Control` headers for images uploaded to AWS S3. It is good practice to cache as much as possible and adding the headers retrospectively to AWS is kind of a pain.

**Usage:**

```js
    {
      maxHeight: 100
      aspect: '1:1'
      format: 'png'
      suffix: '-thumb1'
      awsImageExpires: 31536000
      awsImageMaxAge: 31536000
    }
```

@DavidBennettUK I upstreamed your changes, I hope you are ok with that. 

* https://github.com/Turistforeningen/node-s3-uploader/commit/17704d6597376ef948efa0a443650d8c4f7b1201
* https://github.com/Turistforeningen/node-s3-uploader/commit/d8658dbede4ea517b5652a239f6fef071c9f5d56
* https://github.com/Turistforeningen/node-s3-uploader/commit/361b8e2c64bbebfe90f9959222c0cb753b61e115

Signed-off-by: Hans Kristian Flaatten <hans.kristian.flaatten@turistforeningen.no>