### PR TITLE
Set absolute path when uploadeding image

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ var client = new Upload('my_s3_bucket', {
 
 * **object** `opts`
   * **string** `awsPath` - override the path on AWS set through `opts.aws.path`
+  * **string** `path` - set absolute path for uploaded image (disables random path)
 
 * **function** `cb` - callback function (**Error** `err`, **object[]** `versions`, **object** `meta`)
   * **Error** `err` - `null` if everything went fine

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -93,6 +93,11 @@ Image.prototype.getMetadata = (src, cb) ->
 ##
 Image.prototype.getDest = (cb) ->
   prefix = @opts?.awsPath or @upload.opts.aws.path
+
+  if @opts.path
+    return process.nextTick =>
+      cb null, prefix + @opts.path
+
   @upload._getDestPath prefix, cb
 
 ##

--- a/test/suite.coffee
+++ b/test/suite.coffee
@@ -324,6 +324,21 @@ describe 'Image', ->
         assert.equal path, 'custom/path/aa/bb/cc'
         done()
 
+    it 'returns fixed upload path', (done) ->
+      image.opts.path = 'my/image'
+      image.getDest (err, path) ->
+        assert.ifError err
+        assert.equal path, 'images_test/my/image'
+        done()
+
+    it 'returns fixed upload path with custom prefix', (done) ->
+      image.opts.awsPath = 'custom/path/'
+      image.opts.path = 'my/image'
+      image.getDest (err, path) ->
+        assert.ifError err
+        assert.equal path, 'custom/path/my/image'
+        done()
+
   describe '#resizeVersions()', ->
     it 'resizes image versions', (done) ->
       image.getMetadata image.src, (err, metadata) ->
@@ -459,6 +474,34 @@ describe 'Integration Tests', ->
         assert.equal typeof image.etag, 'string'
         assert.equal typeof image.path, 'string'
         assert.equal typeof image.key, 'string'
+        /^images_test(\/[\w]{2}){3}/.test image.key
+        assert.equal typeof image.url, 'string'
+
+        if image.original
+          assert.equal image.original, true
+        else
+          assert.equal typeof image.suffix, 'string'
+          assert.equal typeof image.height, 'number'
+          assert.equal typeof image.width, 'number'
+
+      done()
+
+  it 'uploads image to fixed path', (done) ->
+    @timeout 10000
+
+    file = __dirname + '/assets/portrait.jpg'
+    opts = path: 'path/to/image'
+
+    upload.upload file, opts, (err, images, meta) ->
+      assert.ifError err
+
+      for image in images
+        cleanup.push Key: image.key if image.key # clean up in AWS
+
+        assert.equal typeof image.etag, 'string'
+        assert.equal typeof image.path, 'string'
+        assert.equal typeof image.key, 'string'
+        /^images_test\/path\/to\/image/.test image.key
         assert.equal typeof image.url, 'string'
 
         if image.original


### PR DESCRIPTION
This PR allows you to set the absolute path when uploading an image. **NB!** This disables the random path. The final path to a version image follows the following rule:  `prefix + path + suffix + ext`

```js
var client = new Uploader('my-s3-bucket');

client.upload('/my/awsome/image.jpg', {
  path: 'custom/your/path/new_filename'
});
```

Signed-off-by: Hans Kristian Flaatten <hans.kristian.flaatten@turistforeningen.no>