### PR TITLE
Upgrade aws-sdk dependency to ^2.2.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,9 +46,9 @@
   "dependencies": {
     "@starefossen/rand-path": "^1.0.1",
     "async": "~1.4",
-    "aws-sdk": "~2.1",
-    "im-resize": "~2.3",
-    "im-metadata": "~2.2"
+    "aws-sdk": "^2.2.9",
+    "im-metadata": "~2.2",
+    "im-resize": "~2.3"
   },
   "engines": {
     "node": ">=0.10",


### PR DESCRIPTION
This PR upgrades `aws-sdk` dependency to `^2.2.9`

Signed-off-by: Hans Kristian Flaatten <hans.kristian.flaatten@turistforeningen.no>