### PR TITLE
Use Node.js v4 for dev and test environments

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 dev:
-  image: starefossen/iojs-imagemagick:latest
+  image: starefossen/node-imagemagick:4-6
   working_dir: /usr/src/app
   volumes:
     - ".:/usr/src/app"

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,4 +1,4 @@
-box: starefossen/iojs-imagemagick:1.0-6.8
+box: starefossen/node-imagemagick:4-6
 
 build:
   steps:


### PR DESCRIPTION
This PR upgrades the local development environment (`docker-compose.yml`) and test environment (`wercker.yml`) to Node.js v4 LTS (`argon`).