### PR TITLE
Reduce npm package size

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "description": "Resize, rename, and upload images to AWS S3",
   "main": "index.js",
   "files": [
-    "index.js",
-    "test"
+    "index.js"
   ],
   "scripts": {
     "codacy-coverage": "codacy-coverage",


### PR DESCRIPTION
Remove `test/` dir from the package published to npm in order to reduce the package size.