### PR TITLE
correct returned url from cn-north-1

### DIFF
--- a/index.js
+++ b/index.js
@@ -150,7 +150,12 @@ const Upload = function Upload(bucketName, opts) {
 
   if (!this.opts.url && this.opts.aws.region === 'us-east-1') {
     this.opts.url = `https://s3.amazonaws.com/${bucketName}/`;
-  } else if (!this.opts.url) {
+  }else if (!this.opts.url && this.opts.aws.region === 'cn-north-1') {
+    this.opts.url = [
+      'https://s3.', this.opts.aws.region,
+      '.amazonaws.com.cn/', bucketName, '/',
+    ].join('');
+  else if (!this.opts.url) {
     this.opts.url = [
       'https://s3-', this.opts.aws.region,
       '.amazonaws.com/', bucketName, '/',


### PR DESCRIPTION
If the S3 bucket is in China region cn-north-1, the original returned url is not considered. please use this change to get the correct url